### PR TITLE
Jpa 매핑, cascade, fetch 학습

### DIFF
--- a/src/main/java/com/study/jpa/JpaRunner.java
+++ b/src/main/java/com/study/jpa/JpaRunner.java
@@ -1,6 +1,8 @@
 package com.study.jpa;
 
 import com.study.jpa.entity.Account;
+import com.study.jpa.entity.Comment;
+import com.study.jpa.entity.Post;
 import com.study.jpa.entity.Study;
 import com.study.jpa.types.UserType;
 import org.hibernate.Session;
@@ -11,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Set;
 
 @Component
 @Transactional
@@ -22,39 +26,27 @@ public class JpaRunner implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) throws Exception {
 
-        Account account = new Account();
-        account.setUserName("Sang Hyuk");
-        account.setPassword("1234");
-        account.setUserType(UserType.NORMAL);
-
-        Account account1 = new Account();
-        account1.setUserName("Jack");
-        account1.setPassword("12345");
-        account1.setUserType(UserType.NORMAL);
-
-        Study study1 = new Study();
-        study1.setName("jpa study");
-        study1.setUser(account);
-
-        Study study2 = new Study();
-        study2.setName("coding test");
-        study2.setUser(account);
-
-        Study study3 = new Study();
-        study3.setName("jpa study2");
-        study3.setUser(account1);
-
-        Study study4 = new Study();
-        study4.setName("coding test2");
-        study4.setUser(account1);
-
+//        Post post = new Post();
+//        post.setContent("post");
+//
+//        Comment comment = new Comment();
+//        comment.setContent("comment1");
+//        comment.setPost(post);
+//
+//
+//        Comment comment2 = new Comment();
+//        comment2.setContent("comment2");
+//        comment2.setPost(post);
+////
+////
         Session session = entityManager.unwrap(Session.class);
+////
+//        session.save(post);
+//        session.save(comment);
+//        session.save(comment2);
 
-        session.save(account);
-        session.save(account1);
-        session.save(study1);
-        session.save(study2);
-        session.save(study3);
-        session.save(study4);
+        Post post = session.get(Post.class,1L);
+
+        session.delete(post);
     }
 }

--- a/src/main/java/com/study/jpa/JpaRunner.java
+++ b/src/main/java/com/study/jpa/JpaRunner.java
@@ -1,0 +1,60 @@
+package com.study.jpa;
+
+import com.study.jpa.entity.Account;
+import com.study.jpa.entity.Study;
+import com.study.jpa.types.UserType;
+import org.hibernate.Session;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Component
+@Transactional
+public class JpaRunner implements ApplicationRunner {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+
+        Account account = new Account();
+        account.setUserName("Sang Hyuk");
+        account.setPassword("1234");
+        account.setUserType(UserType.NORMAL);
+
+        Account account1 = new Account();
+        account1.setUserName("Jack");
+        account1.setPassword("12345");
+        account1.setUserType(UserType.NORMAL);
+
+        Study study1 = new Study();
+        study1.setName("jpa study");
+        study1.setUser(account);
+
+        Study study2 = new Study();
+        study2.setName("coding test");
+        study2.setUser(account);
+
+        Study study3 = new Study();
+        study3.setName("jpa study2");
+        study3.setUser(account1);
+
+        Study study4 = new Study();
+        study4.setName("coding test2");
+        study4.setUser(account1);
+
+        Session session = entityManager.unwrap(Session.class);
+
+        session.save(account);
+        session.save(account1);
+        session.save(study1);
+        session.save(study2);
+        session.save(study3);
+        session.save(study4);
+    }
+}

--- a/src/main/java/com/study/jpa/entity/Account.java
+++ b/src/main/java/com/study/jpa/entity/Account.java
@@ -7,6 +7,8 @@ import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -27,7 +29,6 @@ public class Account {
     private String password;
 
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(nullable = false)
     private Date createDate;
 
     @Embedded
@@ -40,4 +41,7 @@ public class Account {
 
     @Transient
     private String doNotMap;
+
+    @OneToMany(mappedBy = "user")
+    Set<Study> studies = new HashSet<>();
 }

--- a/src/main/java/com/study/jpa/entity/Account.java
+++ b/src/main/java/com/study/jpa/entity/Account.java
@@ -42,6 +42,6 @@ public class Account {
     @Transient
     private String doNotMap;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     Set<Study> studies = new HashSet<>();
 }

--- a/src/main/java/com/study/jpa/entity/Comment.java
+++ b/src/main/java/com/study/jpa/entity/Comment.java
@@ -1,0 +1,23 @@
+package com.study.jpa.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+public class Comment {
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne
+    @Setter
+    private Post post;
+
+    @Setter
+    private String content;
+}

--- a/src/main/java/com/study/jpa/entity/Post.java
+++ b/src/main/java/com/study/jpa/entity/Post.java
@@ -1,0 +1,21 @@
+package com.study.jpa.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Getter
+public class Post {
+    @Id @GeneratedValue
+    private Long id;
+
+    @Setter
+    private String content;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private Set<Comment> comments;
+}

--- a/src/main/java/com/study/jpa/entity/Post.java
+++ b/src/main/java/com/study/jpa/entity/Post.java
@@ -16,6 +16,6 @@ public class Post {
     @Setter
     private String content;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private Set<Comment> comments;
 }

--- a/src/main/java/com/study/jpa/entity/Study.java
+++ b/src/main/java/com/study/jpa/entity/Study.java
@@ -1,0 +1,22 @@
+package com.study.jpa.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+@Setter
+public class Study {
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    private Account user;
+}

--- a/src/main/java/com/study/jpa/entity/Study.java
+++ b/src/main/java/com/study/jpa/entity/Study.java
@@ -3,10 +3,7 @@ package com.study.jpa.entity;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 @Entity
 @Getter


### PR DESCRIPTION
# Jpa Mapping
-----
- DB (Entity)에서 2개의 Table 간의 관계가 형성이 될 수 있다.
 - 예를 들어 게시글, 댓글 관계

## 단방향 관계
**ManyToOne**
- 기본값으로 관계 맺는 상대 객체의 FK로 생성이 된다
- 테이블에 필드가 생긴다.

**OneToMany**
- 기본값은 join 테이블을 생성한다.
- 기본적으로 테이블에 필드가 생기지는 않는다.

ManyToOne vs OneToMany
- 헷갈린다면 뒤에 단어를 보자
- One 이면 컬렉션 사용 x 
- Many 면 컬렉션 사용 o
 


## 양방향 관계

- **ManyToOne 을 정의한 entity가 주인공이 된다.**
- OneToMany 쪽에선 **반드시** mappedBy 를 사용하여 관계를 맺고 있는 필드를 정의해야한다.
- join 등등 여러가지 옵션을 사용할 수 있지만 일반적으로 mappedBy를 사용한다.


# Entity State
----
Entity 에는 총 4가지의 상태가  있다.

**Transient**
- JPA 가 모르는 상태
- git 으로 치면 아직 add 를 하지 않은 상태!

**Persistent**
- JPA가 관리중인 상태
- git 으로 치면 add 를 한 상태
- 이때 한 세션내에 객체에 변화를 (update)를 주더라도 최종적으론 1개의 sql 쿼리문만 전송된다
  - caching 을 한다..?
  - 불필요한 db 접속을 줄여 퍼포먼스 상향에 도움을 준다. + 접속 비용 절감

**Detach**
- JPA 가 더이상 관리하지 않는 상태
- 즉 1개의 session (Transaction) 이 끝나게 되는 경우 JPA 가 더이상 관리하지 않는다.
- 즉 Transaction이 끝났다면 이후의 요청은 또다른 세션에서 진행이 된다.

*Removed**
- JPA 가 관리하기는 함
- 단 삭제하기로 한 상태


# Cascade
----
- 대부분 부모-자식 관계에서 사용한다.
- 영속성 관리의 문제가 발생(부모는 삭제되었지만 자식은 살아있는 경우) 등등을 방지하기 위해 사용된다.

**CascadeType.PERSIST**
- 저장 시에만 전이

**CascadeType.MERGE**
- 병합 시에만 전이 

**CascadeType.REMOVE**
- 삭제 시에만 전의

**CascadeType.REFRESH**
- entity manger 의 refresh 가 호출 시에만 전이

**CascadeType.DETACH**
- parent 가 detach 되면 child 도 detach

**CascadeType.ALL**
- 모든 변경에 대한 전이


>보통은 CascadeType.ALL 을 사용한다고 한다.


# JPA Fetch
---
**Eager**
- 바로 연결된 엔티티를 가져온다.
- ManyToOne 의 default


**Lazy**
- 나중에 연결된 엔티티들을 가져온다.
- OneToMany 의 default


Eager vs Lazy
- 만약 OneToMany 에 연결되어 있는 엔티티가 수백개라고 가정을 해보자
- 지금 쓰지 않는 연결되어 있는 엔티티를 호출할때마다 가져오는건 매우 불필요하다
- 그러므로 이때는 Lazy 를 사용해서 나중에 필요할때 따로 호출해서 가져오는게 훨씬 효과적이다.
- 엔티티의 개수도 적고 지금 해당 엔티티를 사용하기 위해서 연결된 엔티티가 항상 필요하다면 이때는 Eager를 사용한다.