### PR TITLE
JPA 메소드 query, custom repo 만들기

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,21 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.197</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/study/jpa/entity/Post.java
+++ b/src/main/java/com/study/jpa/entity/Post.java
@@ -1,7 +1,6 @@
 package com.study.jpa.entity;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.List;
@@ -9,13 +8,25 @@ import java.util.Set;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
     @Id @GeneratedValue
     private Long id;
 
-    @Setter
+    private String title;
+
+    @Lob
     private String content;
+
+    private Long likeCounts;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private Set<Comment> comments;
+
+    @Builder
+    public Post(String title, String content, Long likeCounts){
+        this.title = title;
+        this.content = content;
+        this.likeCounts = likeCounts;
+    }
 }

--- a/src/main/java/com/study/jpa/entity/Post.java
+++ b/src/main/java/com/study/jpa/entity/Post.java
@@ -10,11 +10,11 @@ import java.util.Set;
 @Entity
 @Getter
 public class Post {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue
     private Long id;
 
     @Setter
-    private String contents;
+    private String content;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private Set<Comment> comments;

--- a/src/main/java/com/study/jpa/entity/Post.java
+++ b/src/main/java/com/study/jpa/entity/Post.java
@@ -10,11 +10,11 @@ import java.util.Set;
 @Entity
 @Getter
 public class Post {
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Setter
-    private String content;
+    private String contents;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private Set<Comment> comments;

--- a/src/main/java/com/study/jpa/repository/PostCustomRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostCustomRepository.java
@@ -1,0 +1,12 @@
+package com.study.jpa.repository;
+
+import com.study.jpa.entity.Post;
+
+import java.util.List;
+
+public interface PostCustomRepository<Post,Long> {
+
+    void customRepository();
+
+    void findAllById(Long id);
+}

--- a/src/main/java/com/study/jpa/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/study/jpa/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.study.jpa.repository;
+
+import com.study.jpa.entity.Post;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class PostCustomRepositoryImpl implements PostCustomRepository<Post,Long> {
+
+    // 커스텀 레포지토리
+    // 커스텀한 기능 만들기
+    @Override
+    public void customRepository() {
+        System.out.println("custom repository");
+    }
+
+    // 기본 기능 덮어쓰기
+    @Override
+    public void findAllById(Long id) {
+        System.out.println("custom find by id");
+    }
+
+}

--- a/src/main/java/com/study/jpa/repository/PostRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<Post,Long> {
+public interface PostRepository extends JpaRepository<Post,Long>,PostCustomRepository<Post,Long> { // custom repo 도 extend
     List<Post> findByContentContainsIgnoreCase(String keyword);
 
     Long countByLikeCountsIsGreaterThanEqual(Long count);

--- a/src/main/java/com/study/jpa/repository/PostRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package com.study.jpa.repository;
+
+
+import com.study.jpa.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post,Long> {
+
+}

--- a/src/main/java/com/study/jpa/repository/PostRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostRepository.java
@@ -4,6 +4,14 @@ package com.study.jpa.repository;
 import com.study.jpa.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post,Long> {
+import java.util.List;
 
+public interface PostRepository extends JpaRepository<Post,Long> {
+    List<Post> findByContentContainsIgnoreCase(String keyword);
+
+    Long countByLikeCountsIsGreaterThanEqual(Long count);
+
+    List<Post> findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqual(String keyword,Long likeCount);
+
+    List<Post> findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqualOrderByLikeCountsDesc(String keyword,Long likeCount);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,12 +6,19 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
+        jdbc:
+          lob:
+            non_contextual_creation: true
         format_sql: true
   datasource:
     url: jdbc:mysql://localhost:3306/jpa_study?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
     username: test
     password: test
     driver-class-name: com.mysql.cj.jdbc.Driver
+  h2:
+    console:
+      path: /h2
+      enabled: true
 logging:
   level:
     org:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,10 @@ spring:
     username: test
     password: test
     driver-class-name: com.mysql.cj.jdbc.Driver
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace

--- a/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.study.jpa.repository;
+
+import com.study.jpa.entity.Post;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class PostRepositoryTest {
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Test
+    public void crudRepo(){
+        Post post = new Post();
+        post.setContent("asd");
+        Post newPost = postRepository.save(post);
+
+        assertThat(newPost.getId()).isNotNull();
+    }
+
+
+}

--- a/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
@@ -51,6 +51,10 @@ public class PostRepositoryTest {
 
 
 
+        postRepository.customRepository();
+
+        // 커스텀하게 구현한건 우선순위가 최상단
+        postRepository.findAllById(1L);
     }
 
 

--- a/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -18,12 +20,37 @@ public class PostRepositoryTest {
     PostRepository postRepository;
 
     @Test
-    public void crudRepo(){
-        Post post = new Post();
-        post.setContent("asd");
-        Post newPost = postRepository.save(post);
+    public void postRepositoryQueryTest(){
 
-        assertThat(newPost.getId()).isNotNull();
+        Post post1 = Post.builder().content("spring post1").title("spring post1").likeCounts(3L).build();
+        Post post2 = Post.builder().content("test content p").title("test title").likeCounts(15L).build();
+        Post post3 = Post.builder().content("ppp").title("bbb").likeCounts(16L).build();
+
+        postRepository.save(post1);
+        postRepository.save(post2);
+        postRepository.save(post3);
+
+        // 문자열을 content 에 포함한 게시글들 찾기
+        List<Post> postList = postRepository.findByContentContainsIgnoreCase("p");
+
+        // 테스트 결과
+        assertThat(postList.size()).isEqualTo(3L);
+
+
+        // 좋아요 개수로 게시글 개수 count
+        long count = postRepository.countByLikeCountsIsGreaterThanEqual(11L);
+
+        // 결과 확인
+        assertThat(count).isEqualTo(2L);
+
+
+        // 좋아요 기준보다 크고 대소문자 상관없이 포함되어 있고
+        List<Post> posts = postRepository.findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqualOrderByLikeCountsDesc("p",10L);
+
+        assertThat(posts).first().hasFieldOrPropertyWithValue("likeCounts",16L);
+
+
+
     }
 
 


### PR DESCRIPTION
# 메소드 query 만들기
----
>example

```java
리턴타입 (접두어)(도입부)By(표현식)(조건식)(AND || OR)(표현식)(조건식)(정렬조건)(매개변수)

//예시
Post getDistinctByTitleContainsIgnoreCaseAndLikeCountsGreaterThanOrderByDesc(String keyword, Long likeCount)
```

- 직접 쿼리를 짜지 않고 이런식으로 메소드만 작성을 해도 JPA 가 자동으로 query 를 짜준다.

**접두어**
- find, get, count

**도입부**
- Distince : 중복제거
- First(N), Top(N) : 처음 N개

**조건식**
- IgnoreCase : 대소문자 구분없이 search 하도록 (upper 를 사용)
- Between : a~b 사이
- LessThan, GreaterThan
- Like 
- Contains
- LessThanEqual, GreaterThanEqual

**정렬 조건**
- ASC : 오름차순
- DESC : 내림차순

>example
OrderByLikeCountDesc



# Custom Repository
------
- 메소드 쿼리를 사용하지 않고 직접 구현할 수 있다.

1. custom interface 생성 후 기능 추가
  - DAO 사용 했던 것처럼 똑같이 구현
  - interface 생성하고 구현 체인 Impl 생성 (반드시 클래스 **이름 마지막에 Impl 로 선언**!!)
  - JpaRepository interface 에 구현한 interface 를 extend 
2. 기본 기능 (findById) 를 덮어 쓸 수 있다.
  - 1번과 같이 구현 하면 됨
  - 단 이때 필요한 타입 (ex. Post, Long 을 명시해줘야함)
  - 기본 findById vs 커스텀 findById
    - 우선순위는 커스텀 findById 가 높다
    - 즉 findById 를 실행하면 기본 메소드가 실행되는것이 아닌 커스텀 메소드가 실행된다.

