### PR TITLE
JPA query dsl 학습

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,17 @@
             <scope>test</scope>
         </dependency>
 
+
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-jpa</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -82,6 +93,24 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+
+            <plugin>
+                <groupId>com.mysema.maven</groupId>
+                <artifactId>apt-maven-plugin</artifactId>
+                <version>1.1.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>target/generated-sources/java</outputDirectory>
+                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/study/jpa/repository/PostCustomRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostCustomRepository.java
@@ -4,9 +4,11 @@ import com.study.jpa.entity.Post;
 
 import java.util.List;
 
-public interface PostCustomRepository<Post,Long> {
+public interface PostCustomRepository {
 
     void customRepository();
 
     void findAllById(Long id);
+
+    List<Post> findPostWithQueryDsl(String contentKeyword, Long likeCount);
 }

--- a/src/main/java/com/study/jpa/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/study/jpa/repository/PostCustomRepositoryImpl.java
@@ -1,12 +1,18 @@
 package com.study.jpa.repository;
 
 import com.study.jpa.entity.Post;
+import com.study.jpa.entity.QPost;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public class PostCustomRepositoryImpl implements PostCustomRepository<Post,Long> {
+public class PostCustomRepositoryImpl extends QuerydslRepositorySupport implements PostCustomRepository {
+
+    public PostCustomRepositoryImpl() {
+        super(Post.class);
+    }
 
     // 커스텀 레포지토리
     // 커스텀한 기능 만들기
@@ -21,4 +27,13 @@ public class PostCustomRepositoryImpl implements PostCustomRepository<Post,Long>
         System.out.println("custom find by id");
     }
 
+    @Override
+    public List<Post> findPostWithQueryDsl(String contentKeyword, Long likeCount){
+        QPost post = QPost.post;
+        return from(post)
+                .where(post.content.containsIgnoreCase(contentKeyword))
+                .where(post.likeCounts.goe(likeCount))
+                .orderBy(post.likeCounts.desc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/study/jpa/repository/PostRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostRepository.java
@@ -3,10 +3,11 @@ package com.study.jpa.repository;
 
 import com.study.jpa.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<Post,Long>,PostCustomRepository<Post,Long> { // custom repo 도 extend
+public interface PostRepository extends JpaRepository<Post,Long>,PostCustomRepository { // custom repo 도 extend
     List<Post> findByContentContainsIgnoreCase(String keyword);
 
     Long countByLikeCountsIsGreaterThanEqual(Long count);

--- a/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.study.jpa.repository;
 
 import com.study.jpa.entity.Post;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,9 +20,8 @@ public class PostRepositoryTest {
     @Autowired
     PostRepository postRepository;
 
-    @Test
-    public void postRepositoryQueryTest(){
-
+    @Before
+    public void beforeJpaTest(){
         Post post1 = Post.builder().content("spring post1").title("spring post1").likeCounts(3L).build();
         Post post2 = Post.builder().content("test content p").title("test title").likeCounts(15L).build();
         Post post3 = Post.builder().content("ppp").title("bbb").likeCounts(16L).build();
@@ -29,7 +29,11 @@ public class PostRepositoryTest {
         postRepository.save(post1);
         postRepository.save(post2);
         postRepository.save(post3);
+    }
 
+
+    @Test
+    public void postRepositoryQueryTest(){
         // 문자열을 content 에 포함한 게시글들 찾기
         List<Post> postList = postRepository.findByContentContainsIgnoreCase("p");
 
@@ -57,5 +61,12 @@ public class PostRepositoryTest {
         postRepository.findAllById(1L);
     }
 
+    @Test
+    public void queryDslTest() {
+        // p 를 포함하고 좋아요 10 이상인 게시글 찾기
+        List<Post> postList = postRepository.findPostWithQueryDsl("p",10L);
 
+        assertThat(postList).first().hasFieldOrPropertyWithValue("likeCounts",16L);
+
+    }
 }


### PR DESCRIPTION
# QueryDSL
-----
**QueryDSL 사용하기**
[여기](http://www.querydsl.com/static/querydsl/4.1.3/reference/html_single/#jpa_integration)에서 maven 과 queryDSL 을 연동하는 방법이 나와 있다.

> pom.xml

```xml
<dependency>
  <groupId>com.querydsl</groupId>
  <artifactId>querydsl-apt</artifactId>
  <version>${querydsl.version}</version>
  <scope>provided</scope>
</dependency>

<dependency>
  <groupId>com.querydsl</groupId>
  <artifactId>querydsl-jpa</artifactId>
  <version>${querydsl.version}</version>
</dependency>
````


```xml
<plugin>
      <groupId>com.mysema.maven</groupId>
      <artifactId>apt-maven-plugin</artifactId>
      <version>1.1.3</version>
      <executions>
        <execution>
          <goals>
            <goal>process</goal>
          </goals>
          <configuration>
            <outputDirectory>target/generated-sources/java</outputDirectory>
            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
          </configuration>
        </execution>
      </executions>
    </plugin>
````

- 이렇게 의존성을 추가하고 plugin 설정을 완료한다.


<img width="754" alt="스크린샷 2020-12-16 오전 12 55 22" src="https://user-images.githubusercontent.com/45462948/102238710-68457400-3f39-11eb-98b6-7bbf5cf9b171.png">

- intellij 기준으로 우측 상단에 maven 을 클릭후 compile 을 클릭한다.

<img width="440" alt="스크린샷 2020-12-16 오전 12 56 29" src="https://user-images.githubusercontent.com/45462948/102238959-b2c6f080-3f39-11eb-97c1-128cd3f09a6d.png">

- 그러면 이렇게 Q가 붙으면서 정의한 Entity들이 생성된다.
- 그러면 연동 끝!!







**들어가기 앞서**
앞서 살펴본 메소드쿼리 매우 편리하지만 메소드 이름이 너~무 길어질 수 있음

findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqualOrderByLikeCountsDesc

이게 한개의 메소드 이름이다.. :(

추가로 입력값들의 type 체크가 불가능하다

등등의 이유로 queryDSL 을 사용한다



**QueryDSL 장점**
- 기존 메소드명 혹은 String 타입의 쿼리가 아닌 코드로 작성
- 매우 단순하고 가독성이 매우 좋음

>example

```java
    @Override
    public List<Post> findPostWithQueryDsl(String contentKeyword, Long likeCount){
        QPost post = QPost.post;
        return from(post)
                .where(post.content.containsIgnoreCase(contentKeyword))
                .where(post.likeCounts.goe(likeCount))
                .orderBy(post.likeCounts.desc())
                .fetch();
    }
```

- findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqualOrderByLikeCountsDesc 이거랑 똑같은 기능을 하는 메소드다
- 메소드 이름도 훨씬 간편하게 짤 수 있고 추가로 input 값들 확인도 할 수 있다.
- 정말 직관적으로 "코드"로 짤 수 있다.


**QueryDSL join**

```java
    @Override
    public List<Post> findPostWithQueryDsl(String contentKeyword, Long likeCount){
        QPost post = QPost.post;
        QComment comment = QComment.comment;

        return from(post)
                .where(post.content.containsIgnoreCase(contentKeyword))
                .where(post.likeCounts.goe(likeCount))
                .join(post.comment, comment) // 조인
                .orderBy(post.likeCounts.desc())
                .fetch();
    }
```
- 조인 역시 정말 간단하게 구성을 할 수 있다.

# Reference
-----
[https://ict-nroo.tistory.com/117](https://ict-nroo.tistory.com/117)

