### PR TITLE
쿼리 직접 생성하는 2가지 방법

### DIFF
--- a/src/main/java/com/study/jpa/entity/Post.java
+++ b/src/main/java/com/study/jpa/entity/Post.java
@@ -9,6 +9,8 @@ import java.util.Set;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NamedQuery(name = "Post.findContent",query = "select p from Post as p where p.content like ?1")
+@NamedNativeQuery(name = "Post.findContentNative", query = "select * from post where content like ?",resultClass = Post.class)
 public class Post {
     @Id @GeneratedValue
     private Long id;

--- a/src/main/java/com/study/jpa/repository/PostRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.study.jpa.repository;
 
 import com.study.jpa.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import java.util.List;
@@ -16,7 +17,13 @@ public interface PostRepository extends JpaRepository<Post,Long>,PostCustomRepos
 
     List<Post> findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqualOrderByLikeCountsDesc(String keyword,Long likeCount);
 
-    Post findContent (String keyWord);
+    Post findContent (String keyword);
 
-    Post findContentNative(String keyWord);
+    Post findContentNative(String keyword);
+
+    @Query("select p from Post As p where p.title = ?1")
+    Post findTitle (String keyword);
+
+    @Query(value = "select * from post where title = ?",nativeQuery = true)
+    Post findTitleNative (String keyword);
 }

--- a/src/main/java/com/study/jpa/repository/PostRepository.java
+++ b/src/main/java/com/study/jpa/repository/PostRepository.java
@@ -15,4 +15,8 @@ public interface PostRepository extends JpaRepository<Post,Long>,PostCustomRepos
     List<Post> findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqual(String keyword,Long likeCount);
 
     List<Post> findByContentContainsIgnoreCaseAndLikeCountsGreaterThanEqualOrderByLikeCountsDesc(String keyword,Long likeCount);
+
+    Post findContent (String keyWord);
+
+    Post findContentNative(String keyWord);
 }

--- a/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
@@ -69,4 +69,13 @@ public class PostRepositoryTest {
         assertThat(postList).first().hasFieldOrPropertyWithValue("likeCounts",16L);
 
     }
+
+    @Test
+    public void namedQuery(){
+        Post post = postRepository.findContent("ppp");
+        Post postNative = postRepository.findContentNative("ppp");
+
+        assertThat(post).isNotNull();
+        assertThat(postNative).isNotNull();
+    }
 }

--- a/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/study/jpa/repository/PostRepositoryTest.java
@@ -71,9 +71,18 @@ public class PostRepositoryTest {
     }
 
     @Test
-    public void namedQuery(){
+    public void namedQueryTest(){
         Post post = postRepository.findContent("ppp");
         Post postNative = postRepository.findContentNative("ppp");
+
+        assertThat(post).isNotNull();
+        assertThat(postNative).isNotNull();
+    }
+
+    @Test
+    public void queryTest(){
+        Post post = postRepository.findTitle("bbb");
+        Post postNative = postRepository.findTitleNative("bbb");
 
         assertThat(post).isNotNull();
         assertThat(postNative).isNotNull();


### PR DESCRIPTION
Query Dsl, method Query 외에 쿼리를 직접 설정할수 있다.

# NamedQuery
-----
- Entity 에 정의한 쿼리를 사용하기
- Entity 에 query를 정의한 후 해당 query 의 name 을 method 에 정의후 사용
- Entity 위에 정의를 하게 되면 가독성이 떨어진다.
- entity 위에 너무도 많은 query 가 작성이 된다.
- 그래서 비추..

>example

```java
@Entity
@NamedQuery(name = "Post.findByContent", query = "select p from Post as p where p.content = ?1")
public class Post{
       @Id @GeneratedValue
    private Long id;

    private String content;
}
```
- 정의한 entity에 이렇게 사용하면 된다.
- 1번째 파라미터에 ?1 2번째는 ?2 이런식으로 파라미터를 삽입할 수 있다.

```java
@Entity
@NamedNativeQuery(name = "Post.findContentNative", query = "select * from post where content= ?",resultClass = Post.class)
public class Post{
       @Id @GeneratedValue
    private Long id;

    private String content;
}
```

- native query 도 사용 가능하다.
- resultClass 로 class 타입을 정의해야한다.


# Query
-----
- NamedQuery 와는 달리 메소드 위에 정의를 해서 사용한다.
- query 관리도 쉽고 가독성도 훨씬 좋기에 namedQuery 보단 이걸 사용하자!

>example

```java
public interface PostRepository extends JpaRepository<Post,Long> {
   @Query("select p from Post As p where p.content = ?1")
   Post findByContent (String keyword);

   @Query(value = "select p from Post As p where p.content = ?", nativeQuery = true)
   Post findByContent (String keyword);
```
  